### PR TITLE
Fix Level hashability

### DIFF
--- a/energy_level_diagram/diagram.py
+++ b/energy_level_diagram/diagram.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 
-@dataclass
+@dataclass(eq=False)
 class Level:
     """Represents a single energy level."""
 


### PR DESCRIPTION
## Summary
- mark `Level` dataclass as `eq=False` so it can be used as a dictionary key

## Testing
- `python - <<'PY'
from energy_level_diagram import Diagram

diagram = Diagram(auto_regulation=True)
col_a = diagram.add_column([0, 1, 2])
col_b = diagram.add_column([0.5, 1.5, 2.5])
diagram.connect(col_a.levels[1], col_b.levels[0])
diagram.plot()
print('plot success')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684201c67564832e9fa8584223e37f56