### PR TITLE
Add label arg and improve plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ A simple library to plot energy level diagrams using Matplotlib. It supports mul
 ```python
 from energy_level_diagram import Diagram
 
-diagram = Diagram(auto_regulation=True)
+diagram = Diagram(auto_regulation=True, label="Example Diagram")
 col_a = diagram.add_column([0, 1, 2])
 col_b = diagram.add_column([0.5, 1.5, 2.5])
 diagram.connect(col_a.levels[1], col_b.levels[0])
-diagram.plot()
+fig, ax = diagram.plot()
 ```
+
+The `label` parameter sets the title of the diagram, and `plot()` now returns the
+``matplotlib`` figure and axes objects for further customisation.

--- a/energy_level_diagram/diagram.py
+++ b/energy_level_diagram/diagram.py
@@ -38,6 +38,7 @@ class Diagram:
 
     columns: List[Column] = field(default_factory=list)
     auto_regulation: bool = True
+    label: Optional[str] = None
     # store explicit connections between levels
     _connections: List[Tuple[Level, Level]] = field(default_factory=list, init=False)
     # store vertical arrows between two levels
@@ -106,7 +107,7 @@ class Diagram:
         show_level_name: bool = False,
         show_column_name: bool = False,
         debug_mode: bool = False,
-    ) -> None:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         fig, ax = plt.subplots()
         positions = self._compute_column_positions()
 
@@ -126,14 +127,15 @@ class Diagram:
                         va="bottom",
                     )
                 level_coords[lvl] = (x, x + col.width, y)
+
             if show_column_name and col.label:
+                col_center = sum(ys) / len(ys) if ys else 0.5
                 ax.text(
                     x + col.width / 2,
-                    0,
+                    col_center,
                     col.label,
                     ha="center",
-                    va="top",
-                    transform=ax.get_xaxis_transform(),
+                    va="center",
                 )
 
         for left, right in self._connections:
@@ -175,6 +177,10 @@ class Diagram:
             ax.set_ylabel("")
             ax.set_xticks([])
             ax.set_yticks([])
-        ax.set_title("Energy Level Diagram")
+        ax.relim()
+        ax.autoscale_view()
+        ax.margins(0.1)
+        ax.set_title(self.label or "Energy Level Diagram")
         plt.show()
+        return fig, ax
 


### PR DESCRIPTION
## Summary
- add optional `label` attribute to `Diagram` used for plot titles
- display column names in the plot center rather than on the axis
- ensure padding using `ax.relim()`/`autosc ale_view`/`margins`
- return `(fig, ax)` from `Diagram.plot`
- update README usage example

## Testing
- `python -m compileall -q .`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_684252c1b624832eb95a4721b1fbde50