### PR TITLE
Add broken arrow feature and padding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ A simple library to plot energy level diagrams using Matplotlib. It supports mul
 The `label` parameter sets the title of the diagram, and `plot()` now returns the
 ``matplotlib`` figure and axes objects for further customisation. Column labels
 are drawn along the bottom of the diagram and the plot limits are calculated from
-the bounding boxes of all artists. A `padding` argument on `plot()` controls the
-extra space around these limits.
+the bounding boxes of all artists. The padding around the plot can be adjusted
+with the `padding` argument or per-side using `padding_left`,
+`padding_right`, `padding_top` and `padding_bottom`. The gap between the lowest
+level and the column labels is controlled by `column_label_gap`.
 
 ## Example scripts
 
@@ -15,6 +17,7 @@ The `examples` directory contains scripts demonstrating typical usage. You can r
 ```
 python examples/basic_usage.py
 python examples/vertical_arrow.py
+python examples/broken_arrow.py
 ```
 
 These scripts create diagrams using different features of the library but do not display their resulting plots here.

--- a/examples/broken_arrow.py
+++ b/examples/broken_arrow.py
@@ -1,0 +1,12 @@
+from energy_level_diagram import Diagram
+
+# Demonstrates using a broken vertical arrow to indicate a large energy gap
+
+diagram = Diagram(auto_regulation=True)
+column = diagram.add_column([0, 1, 5], label="Levels")
+
+# Add a broken arrow between the bottom and top level
+
+diagram.add_vertical_broken_arrow(column.levels[0], column.levels[-1], x=0.25, label="gap")
+
+diagram.plot(show_level_name=True, show_column_name=True)

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -49,6 +49,13 @@ def test_connections_and_arrows():
     assert diagram._arrows == [(col1.levels[1], col2.levels[0], 0.5, "test")]
 
 
+def test_add_vertical_broken_arrow():
+    diagram = Diagram()
+    col = diagram.add_column([0, 1])
+    diagram.add_vertical_broken_arrow(col.levels[0], col.levels[1], x=0.5, label="gap", break_position=0.6)
+    assert diagram._broken_arrows == [(col.levels[0], col.levels[1], 0.5, "gap", 0.6)]
+
+
 def test_plot_invokes_matplotlib(monkeypatch):
     diagram = Diagram()
     diagram.add_column([0, 1])
@@ -60,4 +67,23 @@ def test_plot_invokes_matplotlib(monkeypatch):
 
     monkeypatch.setattr(plt, "show", fake_show)
     diagram.plot(connect=True, show_level_name=True, show_column_name=True, debug_mode=True)
+    assert called.get('show')
+
+
+def test_plot_with_padding(monkeypatch):
+    diagram = Diagram()
+    diagram.add_column([0, 1])
+    called = {}
+
+    def fake_show():
+        called['show'] = True
+
+    monkeypatch.setattr(plt, "show", fake_show)
+    diagram.plot(
+        padding_left=0.1,
+        padding_right=0.2,
+        padding_top=0.3,
+        padding_bottom=0.4,
+        column_label_gap=0.2,
+    )
     assert called.get('show')


### PR DESCRIPTION
## Summary
- allow per-side padding and column label gap
- add broken vertical arrow drawing
- include example for broken arrow
- document new padding options
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842585681bc832ea901394b95f74452