### PR TITLE
Align level label with line start

### DIFF
--- a/energy_level_diagram/diagram.py
+++ b/energy_level_diagram/diagram.py
@@ -159,10 +159,10 @@ class Diagram:
                 ax.hlines(y, x, x + col.width, colors="black")
                 if show_level_name and lvl.label:
                     ax.text(
-                        x + col.width / 2,
+                        x,
                         y + 0.02,
                         lvl.label,
-                        ha="center",
+                        ha="left",
                         va="bottom",
                     )
                 level_coords[lvl] = (x, x + col.width, y)


### PR DESCRIPTION
## Summary
- align energy level labels with the start of the level line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425b0e5d5c832eb5eb660a90d4a8e7