### PR TITLE
Add transition and emission arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ with the `padding` argument or per-side using `padding_left`,
 `padding_right`, `padding_top` and `padding_bottom`. The gap between the lowest
 level and the column labels is controlled by `column_label_gap`.
 
+Transition arrows and spontaneous emission arrows can be drawn with configurable colours.
+
 ## Example scripts
 
 The `examples` directory contains scripts demonstrating typical usage. You can run them directly with Python to see how the diagram API works.
@@ -18,6 +20,7 @@ The `examples` directory contains scripts demonstrating typical usage. You can r
 python examples/basic_usage.py
 python examples/vertical_arrow.py
 python examples/broken_arrow.py
+python examples/transitions_and_emission.py
 ```
 
 These scripts create diagrams using different features of the library but do not display their resulting plots here.

--- a/examples/transitions_and_emission.py
+++ b/examples/transitions_and_emission.py
@@ -1,0 +1,20 @@
+from energy_level_diagram import Diagram
+
+# Demonstrates transition and spontaneous emission arrows
+
+diagram = Diagram(auto_regulation=True)
+col = diagram.add_column([0, 1, 2], label="Levels")
+
+# Add transition from top to middle level with custom color
+
+diagram.add_transition(col.levels[2], col.levels[1], x=0.25, label="transition", color="blue")
+
+# Add spontaneous emission from middle to bottom level
+
+diagram.add_spontaneous_emission(col.levels[1], col.levels[0], x=0.35, label="emission")
+
+# Also show frequency splitting between bottom and top
+
+diagram.add_vertical_arrow(col.levels[0], col.levels[2], x=0.15, label="splitting")
+
+diagram.plot(show_level_name=True, show_column_name=True)

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -46,14 +46,23 @@ def test_connections_and_arrows():
     diagram.connect(col1.levels[0], col2.levels[1])
     diagram.add_vertical_arrow(col1.levels[1], col2.levels[0], x=0.5, label="test")
     assert diagram._connections == [(col1.levels[0], col2.levels[1])]
-    assert diagram._arrows == [(col1.levels[1], col2.levels[0], 0.5, "test")]
+    assert diagram._arrows == [(col1.levels[1], col2.levels[0], 0.5, "test", "black")]
 
 
 def test_add_vertical_broken_arrow():
     diagram = Diagram()
     col = diagram.add_column([0, 1])
     diagram.add_vertical_broken_arrow(col.levels[0], col.levels[1], x=0.5, label="gap", break_position=0.6)
-    assert diagram._broken_arrows == [(col.levels[0], col.levels[1], 0.5, "gap", 0.6)]
+    assert diagram._broken_arrows == [(col.levels[0], col.levels[1], 0.5, "gap", 0.6, "black")]
+
+
+def test_add_transition_and_emission():
+    diagram = Diagram()
+    col = diagram.add_column([0, 1, 2])
+    diagram.add_transition(col.levels[2], col.levels[1], x=0.3)
+    diagram.add_spontaneous_emission(col.levels[1], col.levels[0], x=0.4, color="purple")
+    assert diagram._transitions == [(col.levels[2], col.levels[1], 0.3, None, "blue")]
+    assert diagram._emissions == [(col.levels[1], col.levels[0], 0.4, None, "purple")]
 
 
 def test_plot_invokes_matplotlib(monkeypatch):


### PR DESCRIPTION
## Summary
- support coloured vertical arrows
- add transition and spontaneous emission arrows
- document new features and example
- add tests for transitions and emissions

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842668c65b4832e86c5a5ff5173e85d